### PR TITLE
Use ical.js to build calendar from jCal data

### DIFF
--- a/lib/icaljs.d.ts
+++ b/lib/icaljs.d.ts
@@ -1,0 +1,8 @@
+declare module 'ical.js' {
+  const ICAL: {
+    Component: {
+      fromJSON(data: unknown): { toString(): string };
+    };
+  };
+  export default ICAL;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,13 @@
   "packages": {
     "": {
       "license": "MIT",
+      "dependencies": {
+        "ical.js": "^2.2.1"
+      },
       "devDependencies": {
         "@types/node": "^20.12.7",
         "@vercel/node": "^3.2.20",
-        "pug-cli": "https://codeload.github.com/Zikovic/pug-cli/tar.gz/d39571d206ad2e83e0f98a423067f8f8613a7ed3",
+        "pug-cli": "^1.0.0-alpha6",
         "typescript": "^5.4.5"
       }
     },
@@ -1495,6 +1498,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ical.js": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
+      "license": "MPL-2.0"
     },
     "node_modules/inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "@vercel/node": "^3.2.20",
     "pug-cli": "^1.0.0-alpha6",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "ical.js": "^2.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- add ical.js dependency and a module declaration to allow using it from TypeScript
- generate jCal structures for calendar/events and let ical.js convert them to iCalendar output

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d2b150f1fc8327a03158d0a274d0cd